### PR TITLE
Update expectations lessons and Git Trailers

### DIFF
--- a/2a_remote_expectations_wk1_tuesday.md
+++ b/2a_remote_expectations_wk1_tuesday.md
@@ -51,13 +51,12 @@ If you are having any problems accessing the meeting, reach out to your instruct
 
 We'll be covering the following key coding concepts today. **These concepts will all be required for this section's independent project**, and they are concepts you'll be working with throughout the entire program. Don't worry if all these concepts aren't clear by the end of the week — you'll be practicing them over and over not just this week but throughout your time at Epicodus.
 
-We cover the following concepts in the pre-work and practice them more next class session:
+We will cover the following concepts and practice them this class session:
 
-* Setting up Git in a project
-* Tracking changes with Git
-* Git commit best practices
-* Using Git in the command line
-* Learning the VS Code coding workflow
+* HyperText Markup Language
+* VS Code Live Server
+* HTML Elements and Indentation
+* Inline Elements and Attributes
 
 You will need to be able to use all of the above concepts for this course section's independent project — and for future independent projects as well. Independent project prompts are released on Friday  at the end of the course section and due the following Monday.
 

--- a/2a_remote_expectations_wk1_tuesday_old.md
+++ b/2a_remote_expectations_wk1_tuesday_old.md
@@ -51,13 +51,12 @@ If you are having any problems accessing the meeting, reach out to your instruct
 
 We'll be covering the following key coding concepts today. **These concepts will all be required for this section's independent project**, and they are concepts you'll be working with throughout the entire program. Don't worry if all these concepts aren't clear by the end of the week — you'll be practicing them over and over not just this week but throughout your time at Epicodus.
 
-We cover the following concepts in the pre-work and practice them more next class session:
+We will cover the following concepts and practice them this class session:
 
-* Setting up Git in a project
-* Tracking changes with Git
-* Git commit best practices
-* Using Git in the command line
-* Learning the VS Code coding workflow
+* HyperText Markup Language
+* VS Code Live Server
+* HTML Elements and Indentation
+* Inline Elements and Attributes
 
 You will need to be able to use all of the above concepts for this course section's independent project — and for future independent projects as well. Independent project prompts are released on Thursday at the end of the course section and due the following Sunday.
 

--- a/2ab_tracking_contributions_on_github.md
+++ b/2ab_tracking_contributions_on_github.md
@@ -54,7 +54,7 @@ We start by writing our commit message as usual. However, instead of closing out
 
 For each co-author, we start by adding `Co-authored-by:` followed by a space. Next, we add the preferred name of the co-author as well as the email associated with their Github account. It's very important that the right email is added — otherwise, the co-author won't be correctly attributed in the commit.
 
-Once we are done, we complete the commit with the usual quote marks. Grace Hopper and Ada Lovelace are now contributors on this commit. If we were working on a computer that has a different user in the global git configuration ([see Git Project Setup](https://new.learnhowtoprogram.com/introduction-to-programming/git-html-and-css/practice-git-project-setup) if you need a refresher), that user would also be a contributor.
+Once we are done, we complete the commit with the usual quote marks. Grace Hopper and Ada Lovelace are now contributors on this commit. If we were working on a computer that has a different user in the global git configuration ([see Git Configurations pre-work lesson](https://pre-work.learnhowtoprogram.com/getting-started-with-intro-to-programming/git-configurations) if you need a refresher), that user would also be a contributor.
 
 Let's do one more example — this one will follow the example of having one user hosting a VS Code Live Share session with their pair. The host should already have a global git user and email set up on their machine. For that reason, the commit trailer only needs to include the pair that's being hosted (not the host).
 
@@ -72,5 +72,3 @@ Once you push your code, you should verify that it's correctly showing both cont
 For more information on creating a commit trailer, see [Creating a commit with multiple authors](https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors).
 
 If your commits aren't showing up in the commit graph on your profile and you'd like to troubleshoot, see [Why are my contributions not showing up on my profile?](https://help.github.com/en/github/setting-up-and-managing-your-github-profile/why-are-my-contributions-not-showing-up-on-my-profile).
-
-If you want to read more about viewing your GitHub contributions, see [Viewing contributions on your profile](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-graphs-on-your-profile/viewing-contributions-on-your-profile).

--- a/3a_remote_expectations_wk1_wednesday.md
+++ b/3a_remote_expectations_wk1_wednesday.md
@@ -5,7 +5,7 @@ Welcome to your third day of Epicodus! Today's schedule is fairly similar to yes
 
 Once again, times are approximate.
 
-**8:00 – 8:30 pm: Cohort Scrum with your Instructor**
+**8:00 – 8:30 am: Cohort Scrum with your Instructor**
 
 We'll start class with a Cohort Scrum meeting, with your instructor and your cohort. This is the usual Scrum that you'll take part in every class session for the rest of the program, and we'll meet using the same Google Meet link.
 
@@ -51,15 +51,10 @@ We'll be covering the following key coding concepts today. **These concepts will
 
 The following are brand-new concepts that you'll get lots of opportunity to practice further:
 
-* HTML
-* HTML indentation and spacing
-* HTML block elements
-* HTML inline elements
+* Git as a version control system, and Git commands. 
+* GitHub and Remote Repositories
+* How to use Git and GitHub in your workflow while coding
 
 You will need to be able to use all of the above concepts for this course section's independent project — and for future independent projects as well. Independent project prompts are released on Friday at the end of the course section and due the following Monday.
-
-You'll also have two homework assignments. The first assignment is to read a DEI lesson about social identities. You'll also have the opportunity to write a reflection about this DEI lesson.
-
-The second assignment includes two lessons on Journaling at Epicodus. You are not required to keep a journal while at Epicodus but we recommend keeping one as a tool for reflection and to see your progress throughout the program. In future weeks, the journal prompt will be in the weekend homework. You'll then have an opportunity to discuss the journal prompt with your pair on Monday morning.
 
 **Take note:** on short weeks, daily expectations change, and you may cover more or less content on a given class day.

--- a/3a_remote_expectations_wk1_wednesday_old.md
+++ b/3a_remote_expectations_wk1_wednesday_old.md
@@ -51,10 +51,9 @@ We'll be covering the following key coding concepts today. **These concepts will
 
 The following are brand-new concepts that you'll get lots of opportunity to practice further:
 
-* HTML
-* HTML indentation and spacing
-* HTML block elements
-* HTML inline elements
+* Git as a version control system, and Git commands. 
+* GitHub and Remote Repositories
+* How to use Git and GitHub in your workflow while coding
 
 You will need to be able to use all of the above concepts for this course section's independent project — and for future independent projects as well. Independent project prompts are released on Thursday at the end of the course section and due the following Sunday.
 

--- a/layouts/ft/ft_1_git-html-and-css.yaml
+++ b/layouts/ft/ft_1_git-html-and-css.yaml
@@ -80,6 +80,10 @@ lessons:
     filename: 2_2_github_and_remote_repositories.md
     day: tuesday
     type: lesson
+  - title: Commit Trailers and Github Contributions
+    filename: 2ab_tracking_contributions_on_github.md
+    day: tuesday
+    type: lesson
   - title: Using Git in Your Workflow
     filename: 2_3_epicodus_using_git_in_your_workflow.md
     day: tuesday

--- a/layouts/ft_old/ft_old_1_git-html-and-css.yaml
+++ b/layouts/ft_old/ft_old_1_git-html-and-css.yaml
@@ -80,6 +80,10 @@ lessons:
     filename: 2_2_github_and_remote_repositories.md
     day: tuesday
     type: lesson
+  - title: Commit Trailers and Github Contributions
+    filename: 2ab_tracking_contributions_on_github.md
+    day: tuesday
+    type: lesson
   - title: Using Git in Your Workflow
     filename: 2_3_epicodus_using_git_in_your_workflow.md
     day: tuesday

--- a/layouts/pt/pt_1_git-html-and-css.yaml
+++ b/layouts/pt/pt_1_git-html-and-css.yaml
@@ -84,16 +84,16 @@ lessons:
     filename: 2_2_github_and_remote_repositories.md
     day: wednesday
     type: lesson
+  - title: Commit Trailers and Github Contributions
+    filename: 2ab_tracking_contributions_on_github.md
+    day: wednesday
+    type: lesson
   - title: Using Git in Your Workflow
     filename: 2_3_epicodus_using_git_in_your_workflow.md
     day: wednesday
     type: lesson
   - title: Thursday Schedule and Expectations
     filename: 4a_remote_expectations_wk1_thursday.md
-    day: thursday
-    type: lesson
-  - title: Commit Trailers and Github Contributions
-    filename: 2ab_tracking_contributions_on_github.md
     day: thursday
     type: lesson
   - title: 'CSS: Styling Text and Best Practices'

--- a/layouts/pt_old/pt_old_1_git-html-and-css.yaml
+++ b/layouts/pt_old/pt_old_1_git-html-and-css.yaml
@@ -84,6 +84,10 @@ lessons:
     filename: 2_2_github_and_remote_repositories.md
     day: wednesday
     type: lesson
+  - title: Commit Trailers and Github Contributions
+    filename: 2ab_tracking_contributions_on_github.md
+    day: wednesday
+    type: lesson
   - title: Using Git in Your Workflow
     filename: 2_3_epicodus_using_git_in_your_workflow.md
     day: wednesday

--- a/layouts/pt_old/pt_old_2_git-html-and-css-part-2.yaml
+++ b/layouts/pt_old/pt_old_2_git-html-and-css-part-2.yaml
@@ -12,10 +12,6 @@ lessons:
     day: sunday
     type: exercise
     repo: career-services-full-stack
-  - title: Commit Trailers and Github Contributions
-    filename: 2ab_tracking_contributions_on_github.md
-    day: sunday
-    type: lesson
   - title: 'CSS: Styling Text and Best Practices'
     filename: 2b_css_styling_text.md
     day: sunday


### PR DESCRIPTION
- Fixed the wording of daily expectation lessons for all cohort types where they were incorrect
- Fixed the "Commit Trailers and GitHub Contributions" lesson to accurately link to the pre-work
- Add the Commit Trailers lesson referenced above back into full-time, and arranged it to come after introducing GitHub and Remote Repositories, and before "Using Git in your Workflow", which is a review of all Git concepts, including Trailers/